### PR TITLE
Define order of columns for a sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,20 @@ Convert Javascript objects to XLS (XML format), based on json2officexml.
 var j2xls = require('json2xls-xml')({ pretty : true });
 
 var doc = {
-    Foo : [
-        { firstname : 'John', lastname: 'Doo'}
-        , { firstname : 'Foo', lastname: 'Bar', age: 23, weight: 25.7876, birth : new Date()}
-    ]
-    , Bar : [
-        { firstname : 'Rene', lastname: 'Malin'}
-        , { firstname : 'Foo', lastname: 'foobar', age: 73, weight: 22225.33, birth : new Date()}
-    ]
+    Foo : {
+       columns: ['firstname', 'lastname'],
+       rows: [
+        { firstname : 'John', lastname: 'Doo'},
+        { firstname : 'Foo', lastname: 'Bar', age: 23, weight: 25.7876, birth : new Date()}
+       ]
+    },
+    Bar : {
+        columns:  ['firstname', 'lastname'],,
+        rows: [
+           { firstname : 'Rene', lastname: 'Malin'},
+           { firstname : 'Foo', lastname: 'foobar', age: 73, weight: 22225.33, birth : new Date()}
+        ],
+    },
 };
 
 console.log(j2xls(doc));

--- a/index.js
+++ b/index.js
@@ -53,31 +53,13 @@ ExcelOfficeXmlWriter.prototype.writeDoc = function (obj) {
     .up();
 
     Object.keys(o).forEach(function (sheetTitle) {
-        var rows = o[sheetTitle];
-        var columns;
-
-        if (!Array.isArray(rows) && rows) {
-            rows = [rows];
-        }
+        var rows = o[sheetTitle].rows;
+        var columns = o[sheetTitle].columns;
 
         if (!rows || !rows.length) {
             return;
         }
-
-        //get columns titles based on key's from the first record in the rows array
-        if (rows[0] && typeof rows[0] !== 'object') {
-            columns = [sheetTitle];
-            //make this an array of objects
-            rows = rows.map(function (row) {
-                var tmp = {};
-                tmp[sheetTitle] = row;
-                return tmp;
-            });
-        }
-        else {
-            columns = Object.keys(rows[0] || {});
-        }
-
+        
         child = child.ele("ss:Worksheet").att("ss:Name", sheetTitle).ele("ss:Table");
 
         columns.forEach(function(columnTitle, columnIndex) {


### PR DESCRIPTION
This changes the API for sheet data to have a rows and columns property.

```
var doc = {
    Foo : {
       columns: ['firstname', 'lastname'],
       rows: [
        { firstname : 'John', lastname: 'Doo'},
        { firstname : 'Foo', lastname: 'Bar', age: 23, weight: 25.7876, birth : new Date()}
       ]
    },
    Bar : {
        columns:  ['firstname', 'lastname'],,
        rows: [
           { firstname : 'Rene', lastname: 'Malin'},
           { firstname : 'Foo', lastname: 'foobar', age: 73, weight: 22225.33, birth : new Date()}
        ],
    },
};
```